### PR TITLE
Remove dependency on Json.Net

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@
   branches:
     only:
       - master
-  version: 1.0.{build}
+  version: 1.1.{build}
   build_script:
     build.cmd version=%APPVEYOR_BUILD_VERSION%
   test: off

--- a/source/Halite.Examples.Tests/Halite.Examples.Tests.csproj
+++ b/source/Halite.Examples.Tests/Halite.Examples.Tests.csproj
@@ -40,11 +40,22 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="OrdersResourceTests.cs" />
+    <Compile Include="JsonTestFile.cs" />
+    <Compile Include="OrderLineLinksDeserializationTests.cs" />
+    <Compile Include="OrderLineLinksSerializationTests.cs" />
+    <Compile Include="OrderLineResourceDeserializationTests.cs" />
+    <Compile Include="OrderLineResourceSerializationTests.cs" />
+    <Compile Include="OrdersEmbeddedDeserializationTests.cs" />
+    <Compile Include="OrdersEmbeddedSerializationTests.cs" />
+    <Compile Include="OrdersResourceDeserializationTests.cs" />
+    <Compile Include="OrdersResourceSerializationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="paket.references" />
+    <None Include="TestFiles\OrdersEmbedded.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestFiles\OrdersResource.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -54,10 +65,17 @@
       <Project>{7024ae7a-7c53-43fd-9480-e24bf7b7e884}</Project>
       <Name>Halite.Examples</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Halite.Serialization.JsonNet\Halite.Serialization.JsonNet.csproj">
+      <Project>{4631E21F-0ABA-42E4-A478-379B0656C969}</Project>
+      <Name>Halite.Serialization.JsonNet</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Halite\Halite.csproj">
       <Project>{670c2953-95c3-493c-a39c-987105130378}</Project>
       <Name>Halite</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Choose>

--- a/source/Halite.Examples.Tests/JsonTestFile.cs
+++ b/source/Halite.Examples.Tests/JsonTestFile.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+
+namespace Halite.Examples.Tests
+{
+    public static class JsonTestFile
+    {
+        public static string Read(string fileName)
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var codeBaseUrl = new Uri(assembly.CodeBase);
+            var codeBasePath = Uri.UnescapeDataString(codeBaseUrl.AbsolutePath);
+            var dirPath = Path.GetDirectoryName(codeBasePath);
+            var testDirPath = Path.Combine(dirPath, "TestFiles");
+            var jsonFilePath = Path.Combine(testDirPath, fileName);
+            return string.Join("\n", File.ReadAllLines(jsonFilePath));
+        }
+    }
+}

--- a/source/Halite.Examples.Tests/OrderLineLinksDeserializationTests.cs
+++ b/source/Halite.Examples.Tests/OrderLineLinksDeserializationTests.cs
@@ -1,0 +1,25 @@
+﻿using Halite.Serialization.JsonNet;
+using Newtonsoft.Json;
+using Shouldly;
+using Xunit;
+
+namespace Halite.Examples.Tests
+{
+    public class OrderLineLinksDeserializationTests
+    {
+        [Fact]
+        public void VerifyDeserialization()
+        {
+            var json = "{\"self\":{\"href\":\"/orders/123\"},\"ea:basket\":{\"href\":\"/baskets/98712\"},\"ea:customer\":{\"href\":\"/customers/7809\"}}";
+            var links = Deserialize<OrderLineLinks>(json);
+            links.Self.Href.ToString().ShouldBe("/orders/123");
+            links.BasketLink.Href.ToString().ShouldBe("/baskets/98712");
+            links.CustomerLink.Href.ToString().ShouldBe("/customers/7809");
+        }
+
+        private static T Deserialize<T>(string json)
+        {
+            return JsonConvert.DeserializeObject<T>(json, new HalLinkJsonConverter(), new HalLinksJsonConverter());
+        }
+    }
+}

--- a/source/Halite.Examples.Tests/OrderLineLinksSerializationTests.cs
+++ b/source/Halite.Examples.Tests/OrderLineLinksSerializationTests.cs
@@ -1,0 +1,25 @@
+﻿using Halite.Serialization.JsonNet;
+using Newtonsoft.Json;
+using Shouldly;
+using Xunit;
+
+namespace Halite.Examples.Tests
+{
+    public class OrderLineLinksSerializationTests
+    {
+        [Fact]
+        public void VerifySerialization()
+        {
+            var links = new OrderLineLinks(new SelfLink("/orders/123"), new HalLink("/baskets/98712"),
+                new HalLink("/customers/7809"));
+
+            var json = Serialize(links);
+            json.ShouldBe("{\"self\":{\"href\":\"/orders/123\"},\"ea:basket\":{\"href\":\"/baskets/98712\"},\"ea:customer\":{\"href\":\"/customers/7809\"}}");
+        }
+
+        private static string Serialize(object obj)
+        {
+            return JsonConvert.SerializeObject(obj, new HalLinkJsonConverter(), new HalLinksJsonConverter());
+        }
+    }
+}

--- a/source/Halite.Examples.Tests/OrderLineResourceDeserializationTests.cs
+++ b/source/Halite.Examples.Tests/OrderLineResourceDeserializationTests.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using Halite.Serialization.JsonNet;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Shouldly;
+using Xunit;
+
+namespace Halite.Examples.Tests
+{
+    public class OrderLineResourceDeserializationTests
+    {
+        [Fact]
+        public void VerifyDeserialization()
+        {
+            var json = "{\"_links\":{\"self\":{\"href\":\"/orders/123\"},\"ea:basket\":{\"href\":\"/baskets/98712\"},\"ea:customer\":{\"href\":\"/customers/7809\"}},\"total\":30.0,\"currency\":\"USD\",\"status\":\"shipped\"}";
+            var resource = Deserialize<OrderLineResource>(json);
+            resource.Links.ShouldNotBeNull();
+            resource.Links.Self.Href.ToString().ShouldBe("/orders/123");
+        }
+
+        private static T Deserialize<T>(string json)
+        {
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                Converters = new List<JsonConverter>()
+                {
+                    new HalLinkJsonConverter(),
+                    new HalLinksJsonConverter(),
+                    new HalResourceJsonConverter()
+                }
+            };
+            return JsonConvert.DeserializeObject<T>(json, settings);
+        }
+    }
+}

--- a/source/Halite.Examples.Tests/OrderLineResourceSerializationTests.cs
+++ b/source/Halite.Examples.Tests/OrderLineResourceSerializationTests.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using Halite.Serialization.JsonNet;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Shouldly;
+using Xunit;
+
+namespace Halite.Examples.Tests
+{
+    public class OrderLineResourceSerializationTests
+    {
+        [Fact]
+        public void VerifySerialization()
+        {
+            var resource = new OrderLineResource(new decimal(30.00), "USD", "shipped")
+            {
+                Links = new OrderLineLinks(new SelfLink("/orders/123"),
+                    new HalLink("/baskets/98712"),
+                    new HalLink("/customers/7809"))
+            };
+
+            var json = Serialize(resource);
+            json.ShouldBe("{\"_links\":{\"self\":{\"href\":\"/orders/123\"},\"ea:basket\":{\"href\":\"/baskets/98712\"},\"ea:customer\":{\"href\":\"/customers/7809\"}},\"total\":30.0,\"currency\":\"USD\",\"status\":\"shipped\"}");
+        }
+
+        private static string Serialize(object obj)
+        {
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                Converters = new List<JsonConverter>()
+                {
+                    new HalLinkJsonConverter(),
+                    new HalLinksJsonConverter(),
+                    new HalResourceJsonConverter()
+                }
+            };
+            return JsonConvert.SerializeObject(obj, settings);
+        }
+    }
+}

--- a/source/Halite.Examples.Tests/OrdersEmbeddedDeserializationTests.cs
+++ b/source/Halite.Examples.Tests/OrdersEmbeddedDeserializationTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.IO;
+using Halite.Serialization.JsonNet;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Shouldly;
+using Xunit;
+
+namespace Halite.Examples.Tests
+{
+    public class OrdersEmbeddedDeserializationTests
+    {
+        [Fact]
+        public void VerifyOrdersResource()
+        {
+            var json = JsonTestFile.Read("OrdersEmbedded.json");
+            var embedded = Deserialize<OrdersEmbedded>(json);
+            embedded.ShouldNotBeNull();
+        }
+
+        private static T Deserialize<T>(string json)
+        {
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                Converters = new List<JsonConverter>()
+                {
+                    new HalLinkJsonConverter(),
+                    new HalLinksJsonConverter(),
+                    new HalEmbeddedJsonConverter(),
+                    new HalResourceJsonConverter()
+                }
+            };
+            return JsonConvert.DeserializeObject<T>(json, settings);
+        }
+    }
+}

--- a/source/Halite.Examples.Tests/OrdersEmbeddedSerializationTests.cs
+++ b/source/Halite.Examples.Tests/OrdersEmbeddedSerializationTests.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Halite.Serialization.JsonNet;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Shouldly;
+using Xunit;
+
+namespace Halite.Examples.Tests
+{
+    public class OrdersEmbeddedSerializationTests
+    {
+        [Fact]
+        public void VerifySerialization()
+        {
+            var embedded = CreateOrdersEmbedded();
+            var json = Serialize(embedded);
+            json.ShouldNotBeNull();
+            json.ShouldBe(JsonTestFile.Read("OrdersEmbedded.json"));
+        }
+
+        private static OrdersEmbedded CreateOrdersEmbedded()
+        {
+            return new OrdersEmbedded(new List<OrderLineResource>
+            {
+                new OrderLineResource(30.00m, "USD", "shipped")
+                {
+                    Links = new OrderLineLinks(new SelfLink("/orders/123"),
+                        new HalLink("/baskets/98712"),
+                        new HalLink("/customers/7809"))
+                },
+                new OrderLineResource(20.00m, "USD", "processing")
+                {
+                    Links = new OrderLineLinks(new SelfLink("/orders/124"),
+                        new HalLink("/baskets/97213"),
+                        new HalLink("/customers/12369"))
+                }
+            });
+        }
+
+        private static string Serialize(object o)
+        {
+            var serializer = new JsonSerializer
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                Formatting = Formatting.Indented,
+                Converters =
+                {
+                    new HalLinkJsonConverter(),
+                    new HalLinksJsonConverter(),
+                    new HalEmbeddedJsonConverter(),
+                    new HalResourceJsonConverter()
+                }
+            };
+
+            using (var sw = new StringWriter { NewLine = "\n" })
+            using (JsonWriter writer = new JsonTextWriter(sw)
+            {
+                Indentation = 2,
+            })
+            {
+                serializer.Serialize(writer, o);
+                return sw.ToString();
+            }
+        }
+    }
+}

--- a/source/Halite.Examples.Tests/OrdersResourceDeserializationTests.cs
+++ b/source/Halite.Examples.Tests/OrdersResourceDeserializationTests.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using Halite.Serialization.JsonNet;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Shouldly;
+using Xunit;
+
+namespace Halite.Examples.Tests
+{
+    public class OrdersResourceDeserializationTests
+    {
+        [Fact]
+        public void VerifyOrdersResourceDeserialization()
+        {
+            var json = JsonTestFile.Read("OrdersResource.json");
+            var resource = Deserialize<OrdersResource>(json);
+            resource.ShouldNotBeNull();
+        }
+
+        private static T Deserialize<T>(string json)
+        {
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                Converters = new List<JsonConverter>()
+                {
+                    new HalLinkJsonConverter(),
+                    new HalLinksJsonConverter(),
+                    new HalEmbeddedJsonConverter(),
+                    new HalResourceJsonConverter()
+                }
+            };
+            return JsonConvert.DeserializeObject<T>(json, settings);
+        }
+    }
+}

--- a/source/Halite.Examples.Tests/OrdersResourceSerializationTests.cs
+++ b/source/Halite.Examples.Tests/OrdersResourceSerializationTests.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
+using Halite.Serialization.JsonNet;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Shouldly;
@@ -9,25 +8,14 @@ using Xunit;
 
 namespace Halite.Examples.Tests
 {
-    public class OrdersResourceTests
+    public class OrdersResourceSerializationTests
     {
-        private static string ReadJsonFile(string fileName)
-        {
-            var assembly = Assembly.GetExecutingAssembly();
-            var codeBaseUrl = new Uri(assembly.CodeBase);
-            var codeBasePath = Uri.UnescapeDataString(codeBaseUrl.AbsolutePath);
-            var dirPath = Path.GetDirectoryName(codeBasePath);
-            var testDirPath = Path.Combine(dirPath, "TestFiles");
-            var jsonFilePath = Path.Combine(testDirPath, fileName);
-            return string.Join("\n", File.ReadAllLines(jsonFilePath));
-        } 
-
         [Fact]
-        public void VerifyOrdersResource()
+        public void VerifyOrdersResourceSerialization()
         {
             var resource = CreateOrdersResource();
             var json = Serialize(resource);
-            json.ShouldBe(ReadJsonFile("OrdersResource.json"));
+            json.ShouldBe(JsonTestFile.Read("OrdersResource.json"));
         }
 
         private static string Serialize(object o)
@@ -36,6 +24,13 @@ namespace Halite.Examples.Tests
             {
                 ContractResolver = new CamelCasePropertyNamesContractResolver(),
                 Formatting = Formatting.Indented,
+                Converters =
+                {
+                    new HalLinkJsonConverter(),
+                    new HalLinksJsonConverter(),
+                    new HalEmbeddedJsonConverter(),
+                    new HalResourceJsonConverter()
+                }
             };
 
             using (var sw = new StringWriter { NewLine = "\n" })

--- a/source/Halite.Examples.Tests/TestFiles/OrdersEmbedded.json
+++ b/source/Halite.Examples.Tests/TestFiles/OrdersEmbedded.json
@@ -1,0 +1,36 @@
+﻿{
+  "ea:order": [
+    {
+      "_links": {
+        "self": {
+          "href": "/orders/123"
+        },
+        "ea:basket": {
+          "href": "/baskets/98712"
+        },
+        "ea:customer": {
+          "href": "/customers/7809"
+        }
+      },
+      "total": 30.00,
+      "currency": "USD",
+      "status": "shipped"
+    },
+    {
+      "_links": {
+        "self": {
+          "href": "/orders/124"
+        },
+        "ea:basket": {
+          "href": "/baskets/97213"
+        },
+        "ea:customer": {
+          "href": "/customers/12369"
+        }
+      },
+      "total": 20.00,
+      "currency": "USD",
+      "status": "processing"
+    }
+  ]
+}

--- a/source/Halite.Examples/Halite.xml
+++ b/source/Halite.Examples/Halite.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>Halite.Examples</name>
+    </assembly>
+    <members>
+    </members>
+</doc>

--- a/source/Halite.Examples/OrderLineLinks.cs
+++ b/source/Halite.Examples/OrderLineLinks.cs
@@ -11,11 +11,11 @@ namespace Halite.Examples
             CustomerLink = customerLink;
         }
 
-        [JsonProperty("ea:basket", Order = 0)]
+        [HalRelation("ea:basket")]
         [NotNull]
         public HalLink BasketLink { get; }
 
-        [JsonProperty("ea:customer", Order = 0)]
+        [HalRelation("ea:customer")]
         [NotNull]
         public HalLink CustomerLink { get; }
     }

--- a/source/Halite.Examples/OrderLineResource.cs
+++ b/source/Halite.Examples/OrderLineResource.cs
@@ -9,10 +9,13 @@
             Status = status;
         }
 
+        [HalProperty("total")]
         public decimal Total { get; }
 
+        [HalProperty("currency")]
         public string Currency { get; }
 
+        [HalProperty("status")]
         public string Status { get; }
     }
 }

--- a/source/Halite.Examples/OrdersEmbedded.cs
+++ b/source/Halite.Examples/OrdersEmbedded.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
 
 namespace Halite.Examples
 {
@@ -10,7 +9,7 @@ namespace Halite.Examples
             OrderLines = orderLines;
         }
 
-        [JsonProperty("ea:order")]
+        [HalRelation("ea:order")]
         public IReadOnlyList<OrderLineResource> OrderLines { get; }
     }
 }

--- a/source/Halite.Examples/OrdersLinks.cs
+++ b/source/Halite.Examples/OrdersLinks.cs
@@ -14,19 +14,19 @@ namespace Halite.Examples
             AdminLinks = adminLinks;
         }
 
-        [JsonProperty("curies", Order = 0)]
+        [HalRelation("curies")]
         [NotNull]
         public IReadOnlyList<HalTemplatedLink> CuriesLinks { get; }
 
-        [JsonProperty("next", Order = 0)]
+        [HalRelation("next")]
         [NotNull]
         public HalLink NextLink { get; }
 
-        [JsonProperty("ea:find", Order = 0)]
+        [HalRelation("ea:find")]
         [NotNull]
         public HalTemplatedLink FindLink { get; }
 
-        [JsonProperty("ea:admin", Order = 0)]
+        [HalRelation("ea:admin")]
         [NotNull]
         public IReadOnlyList<HalLink> AdminLinks { get; }
     }

--- a/source/Halite.Examples/OrdersResource.cs
+++ b/source/Halite.Examples/OrdersResource.cs
@@ -2,8 +2,10 @@
 {
     public class OrdersResource : HalResource<OrdersLinks, OrdersEmbedded>
     {
+        [HalProperty("currentlyProcessing")]
         public int CurrentlyProcessing { get; set; }
 
+        [HalProperty("shippedToday")]
         public int ShippedToday { get; set; }
     }
 }

--- a/source/Halite.Serialization.JsonNet/HalLinkJsonConverter.cs
+++ b/source/Halite.Serialization.JsonNet/HalLinkJsonConverter.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Halite.Serialization.JsonNet
+{
+    public class HalLinkJsonConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jo = JObject.Load(reader);
+
+                var ctor = SelectConstructor(objectType);
+                if (ctor == null)
+                {
+                    throw CreateConstructorException(objectType);
+                }
+
+                var instance = CreateInstance(objectType, ctor, jo);
+
+                AssignValues(objectType, instance, jo);
+
+                return instance;
+            }
+
+            throw new InvalidOperationException();
+        }
+
+        private static JsonSerializationException CreateConstructorException(Type objectType)
+        {
+            return new JsonSerializationException($"Unable to find a constructor to use for type {objectType}. A class should either have a default constructor, one constructor with arguments or a constructor marked with the JsonConstructor attribute.");
+        }
+
+        private static void AssignValues(Type objectType, HalLinkObject instance, JObject jo)
+        {
+            var properties = objectType.GetProperties().Where(p => p.SetMethod != null && p.GetMethod != null).ToList();
+
+            foreach (var prop in properties)
+            {
+                var jop = jo.Properties().FirstOrDefault(it =>
+                    string.Equals(it.Name, prop.Name, StringComparison.InvariantCultureIgnoreCase));
+                if (jop != null)
+                {
+                    var currentValue = prop.GetMethod.Invoke(instance, new object[0]);
+                    if (currentValue == null)
+                    {
+                        var jvalue = (JValue)jop.Value;
+                        var objValue = jvalue.Value;
+                        var value = typeof(Uri) == prop.PropertyType
+                            ? new Uri((string)objValue, UriKind.RelativeOrAbsolute)
+                            : objValue;
+                        prop.SetMethod.Invoke(instance, new[] { value });
+                    }
+                }
+            }
+        }
+
+        private static HalLinkObject CreateInstance(Type objectType, ConstructorInfo ctor, JObject item)
+        {
+            var args = ctor.GetParameters().Select(p => LookupArgument(objectType, p, item)).ToArray();
+            try
+            {
+                return (HalLinkObject) ctor.Invoke(args);
+            }
+            catch (TargetInvocationException ex)
+            {
+                if (ex.InnerException != null)
+                {
+                    throw ex.InnerException;
+                }
+
+                throw;
+            }
+        }
+
+        private static object LookupArgument(Type objectType, ParameterInfo parameter, JObject item)
+        {
+            var property = item.Properties().FirstOrDefault(prop => string.Equals(parameter.Name, prop.Name, StringComparison.InvariantCultureIgnoreCase));
+            if (property == null)
+            {
+                throw CreateConstructorException(objectType);
+            }
+
+            var jval = (JValue) property.Value;
+            var val = jval?.Value;
+            if (val != null)
+            {
+                if (!parameter.ParameterType.IsInstanceOfType(val))
+                {
+                    throw CreateConstructorException(objectType);
+                }
+            }
+
+            return val;
+        }
+
+        private static ConstructorInfo SelectConstructor(Type objectType)
+        {
+            return SelectHalLinkConstructor(objectType) ??
+                   SelectSubclassConstructor(objectType);
+        }
+
+        private static ConstructorInfo SelectHalLinkConstructor(Type objectType)
+        {
+            if (objectType == typeof(HalLink) || objectType == typeof(HalTemplatedLink))
+            {
+                return objectType.GetConstructors().Single(AcceptsSingleStringParameter);
+            }
+
+            return null;
+        }
+
+        private static bool AcceptsSingleStringParameter(ConstructorInfo ctor)
+        {
+            var parameters = ctor.GetParameters();
+            return parameters.Length == 1 && parameters[0].ParameterType == typeof(string);
+        }
+
+        private static ConstructorInfo SelectSubclassConstructor(Type objectType)
+        {
+            var constructors = objectType.GetConstructors();
+
+            return SelectAnnotatedJsonConstructor(constructors) ??
+                   SelectDefaultConstructor(constructors) ??
+                   SelectConstructorWithParameters(constructors);
+        }
+
+        private static ConstructorInfo SelectAnnotatedJsonConstructor(IReadOnlyList<ConstructorInfo> constructors)
+        {
+            return constructors.SingleOrDefault(ctor => ctor.GetCustomAttributes(typeof(JsonConstructorAttribute), false).Any());
+        }
+
+        private static ConstructorInfo SelectDefaultConstructor(IReadOnlyList<ConstructorInfo> constructors)
+        {
+            return constructors.SingleOrDefault(ctor => !ctor.GetParameters().Any());
+        }
+
+        private static ConstructorInfo SelectConstructorWithParameters(IReadOnlyList<ConstructorInfo> ctors)
+        {
+            return ctors.Count == 1 ? ctors[0] : null;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            var result = typeof(HalLinkObject).IsAssignableFrom(objectType);
+            return result;
+        }
+    }
+}

--- a/source/Halite.Serialization.JsonNet/HalResourceJsonConverter.cs
+++ b/source/Halite.Serialization.JsonNet/HalResourceJsonConverter.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Halite.Serialization.JsonNet
+{
+    public class HalResourceJsonConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var objectType = value.GetType();
+            var jo = new JObject();
+
+            var properties = objectType.GetInheritanceChain()
+                .Reverse()
+                .SelectMany(it => it.GetImmediateProperties())
+                .ToList();
+
+            var linksProperty = properties.Single(p => string.Equals("Links", p.Name));
+            var embeddedProperty = properties.SingleOrDefault(p => string.Equals("Embedded", p.Name));
+            var halResourceProperties = new[] {linksProperty, embeddedProperty}.Where(it => it != null);
+
+            var regularProperties = properties.Except(halResourceProperties);
+
+            AddPropertyValue(jo, "_links", linksProperty, value, serializer);
+
+            foreach (var prop in regularProperties.Where(p => p.CanRead))
+            {
+                AddPropertyValue(jo, prop.GetPropertyName(), prop, value, serializer);
+            }
+
+            if (embeddedProperty != null)
+            {
+                AddPropertyValue(jo, "_embedded", embeddedProperty, value, serializer);
+            }
+
+            jo.WriteTo(writer);
+        }
+
+        private static void AddPropertyValue(JObject jo, string name, PropertyInfo prop, object value, JsonSerializer serializer)
+        {
+            var propVal = prop.GetValue(value, null);
+            if (propVal != null)
+            {
+                jo.Add(name, JToken.FromObject(propVal, serializer));
+            }
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jo = JObject.Load(reader);
+
+                var ctor = SelectConstructor(objectType);
+                if (ctor == null)
+                {
+                    throw CreateConstructorException(objectType);
+                }
+
+                var instance = CreateInstance(objectType, ctor, jo, serializer);
+
+                AssignValues(objectType, instance, jo, serializer);
+
+                return instance;
+            }
+
+            throw new InvalidOperationException();
+        }
+
+        private static JsonSerializationException CreateConstructorException(Type objectType)
+        {
+            return new JsonSerializationException($"Unable to find a constructor to use for type {objectType}. A class should either have a default constructor, one constructor with arguments or a constructor marked with the JsonConstructor attribute.");
+        }
+
+        private static void AssignValues(Type objectType, object instance, JObject jo, JsonSerializer serializer)
+        {
+            var properties = objectType.GetProperties().Where(p => p.SetMethod != null && p.GetMethod != null).ToList();
+
+            foreach (var prop in properties)
+            {
+                var jop = jo.Properties().FirstOrDefault(it =>
+                    string.Equals(it.Name, prop.GetPropertyName(), StringComparison.InvariantCultureIgnoreCase));
+                if (jop != null)
+                {
+                    var currentValue = prop.GetMethod.Invoke(instance, new object[0]);
+                    if (currentValue == null)
+                    {
+                        var value = jop.Value.ToObject(prop.PropertyType, serializer);
+                        prop.SetMethod.Invoke(instance, new[] { value });
+                    }
+                }
+            }
+        }
+
+        private static object CreateInstance(Type objectType, ConstructorInfo ctor, JObject item, JsonSerializer serializer)
+        {
+            var args = ctor.GetParameters().Select(p => LookupArgument(objectType, p, item, serializer)).ToArray();
+            try
+            {
+                return ctor.Invoke(args);
+            }
+            catch (TargetInvocationException ex)
+            {
+                if (ex.InnerException != null)
+                {
+                    throw ex.InnerException;
+                }
+
+                throw;
+            }
+        }
+
+        private static object LookupArgument(Type objectType, ParameterInfo parameter, JObject item, JsonSerializer serializer)
+        {
+            var prop = FindCorrespondingProperty(objectType, parameter.Name);
+            if (prop == null)
+            {
+                throw CreateConstructorException(objectType);
+            }
+
+            var jprop = item.Properties().FirstOrDefault(it => string.Equals(prop.GetPropertyName(), it.Name, StringComparison.InvariantCultureIgnoreCase));
+            if (jprop == null)
+            {
+                throw CreateConstructorException(objectType);
+            }
+
+            var val = jprop.Value.ToObject(parameter.ParameterType, serializer);
+            return val;
+        }
+
+        private static PropertyInfo FindCorrespondingProperty(Type objectType, string parameterName)
+        {
+            return objectType.GetProperties().FirstOrDefault(it =>
+                string.Equals(it.Name, parameterName, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+
+        private static ConstructorInfo SelectConstructor(Type objectType)
+        {
+            var constructors = objectType.GetConstructors();
+
+            return SelectAnnotatedJsonConstructor(constructors) ??
+                   SelectDefaultConstructor(constructors) ??
+                   SelectConstructorWithParameters(constructors);
+        }
+
+        private static ConstructorInfo SelectAnnotatedJsonConstructor(IReadOnlyList<ConstructorInfo> constructors)
+        {
+            return constructors.SingleOrDefault(ctor => ctor.GetCustomAttributes(typeof(JsonConstructorAttribute), false).Any());
+        }
+
+        private static ConstructorInfo SelectDefaultConstructor(IReadOnlyList<ConstructorInfo> constructors)
+        {
+            return constructors.SingleOrDefault(ctor => !ctor.GetParameters().Any());
+        }
+
+        private static ConstructorInfo SelectConstructorWithParameters(IReadOnlyList<ConstructorInfo> ctors)
+        {
+            return ctors.Count == 1 ? ctors[0] : null;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            var res = IsHalResourceType(objectType);
+            return res;
+        }
+
+        private static bool IsHalResourceType(Type type)
+        {
+            return type != null &&
+                   (IsExactlyHalResourceType(type) || IsHalResourceType(type.BaseType));
+        }
+
+        private static bool IsExactlyHalResourceType(Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(HalResource<>);
+        }
+    }
+}

--- a/source/Halite.Serialization.JsonNet/Halite.Serialization.JsonNet.csproj
+++ b/source/Halite.Serialization.JsonNet/Halite.Serialization.JsonNet.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{670C2953-95C3-493C-A39C-987105130378}</ProjectGuid>
+    <ProjectGuid>{4631E21F-0ABA-42E4-A478-379B0656C969}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Halite</RootNamespace>
-    <AssemblyName>Halite</AssemblyName>
+    <RootNamespace>Halite.Serialization.JsonNet</RootNamespace>
+    <AssemblyName>Halite.Serialization.JsonNet</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -40,15 +40,14 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="HalEmbedded.cs" />
-    <Compile Include="HalLink.cs" />
-    <Compile Include="HalLinkObject.cs" />
-    <Compile Include="HalLinks.cs" />
-    <Compile Include="HalPropertyAttribute.cs" />
-    <Compile Include="HalResource.cs" />
-    <Compile Include="HalTemplatedLink.cs" />
+    <Compile Include="HalLinkJsonConverter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SelfLink.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Halite\Halite.csproj">
+      <Project>{670c2953-95c3-493c-a39c-987105130378}</Project>
+      <Name>Halite</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="paket.references" />
@@ -59,6 +58,17 @@
       <ItemGroup>
         <Reference Include="JetBrains.Annotations">
           <HintPath>..\..\packages\JetBrains.Annotations\lib\net20\JetBrains.Annotations.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="Newtonsoft.Json">
+          <HintPath>..\..\packages\Newtonsoft.Json\lib\net45\Newtonsoft.Json.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/source/Halite.Serialization.JsonNet/Halite.Serialization.JsonNet.csproj
+++ b/source/Halite.Serialization.JsonNet/Halite.Serialization.JsonNet.csproj
@@ -40,8 +40,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="HalEmbeddedJsonConverter.cs" />
     <Compile Include="HalLinkJsonConverter.cs" />
+    <Compile Include="HalLinksJsonConverter.cs" />
+    <Compile Include="HalResourceJsonConverter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PropertyInfoExtensions.cs" />
+    <Compile Include="TypeExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Halite\Halite.csproj">

--- a/source/Halite.Serialization.JsonNet/Halite.Serialization.JsonNet.csproj
+++ b/source/Halite.Serialization.JsonNet/Halite.Serialization.JsonNet.csproj
@@ -46,6 +46,7 @@
     <Compile Include="HalResourceJsonConverter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyInfoExtensions.cs" />
+    <Compile Include="SerializerConfigExtensions.cs" />
     <Compile Include="TypeExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Halite.Serialization.JsonNet/Properties/AssemblyInfo.cs
+++ b/source/Halite.Serialization.JsonNet/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Halite.Serialization.JsonNet")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Halite.Serialization.JsonNet")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4631e21f-0aba-42e4-a478-379b0656c969")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/Halite.Serialization.JsonNet/PropertyInfoExtensions.cs
+++ b/source/Halite.Serialization.JsonNet/PropertyInfoExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Reflection;
+using Newtonsoft.Json;
+
+namespace Halite.Serialization.JsonNet
+{
+    internal static class PropertyInfoExtensions
+    {
+        public static string GetRelationName(this PropertyInfo prop)
+        {
+            var attribute = prop.GetCustomAttribute(typeof(HalRelationAttribute)) as HalRelationAttribute;
+            return attribute == null ? prop.Name : attribute.Name;
+        }
+
+        public static string GetPropertyName(this PropertyInfo prop)
+        {
+            var attribute = prop.GetCustomAttribute(typeof(HalPropertyAttribute)) as HalPropertyAttribute;
+            return attribute == null ? prop.Name : attribute.Name;
+        }
+    }
+}

--- a/source/Halite.Serialization.JsonNet/SerializerConfigExtensions.cs
+++ b/source/Halite.Serialization.JsonNet/SerializerConfigExtensions.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Halite.Serialization.JsonNet
+{
+    public static class SerializerConfigExtensions
+    {
+        public static JsonSerializerSettings ConfigureForHalite(this JsonSerializerSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            foreach (var c in GetHaliteConverters())
+            {
+                settings.Converters.Add(c);
+            }
+
+            return settings;
+        }
+
+        public static JsonSerializer ConfigureForHalite(this JsonSerializer serializer)
+        {
+            if (serializer == null)
+            {
+                throw new ArgumentNullException(nameof(serializer));
+            }
+
+            foreach (var c in GetHaliteConverters())
+            {
+                serializer.Converters.Add(c);
+            }
+
+            return serializer;
+        }
+
+        private static IEnumerable<JsonConverter> GetHaliteConverters()
+        {
+            yield return new HalLinkJsonConverter();
+            yield return new HalLinksJsonConverter();
+            yield return new HalEmbeddedJsonConverter();
+            yield return new HalResourceJsonConverter();
+        }
+    }
+}

--- a/source/Halite.Serialization.JsonNet/TypeExtensions.cs
+++ b/source/Halite.Serialization.JsonNet/TypeExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Halite.Serialization.JsonNet
+{
+    internal static class TypeExtensions
+    {
+        public static IEnumerable<Type> GetInheritanceChain(this Type type)
+        {
+            var t = type;
+            while (t != null && t != typeof(object))
+            {
+                yield return t;
+                t = t.BaseType;
+            }
+        }
+
+        public static IEnumerable<PropertyInfo> GetImmediateProperties(this Type type)
+        {
+            return type.GetProperties(BindingFlags.Public
+                                      | BindingFlags.Instance
+                                      | BindingFlags.DeclaredOnly);
+        }
+    }
+}

--- a/source/Halite.Serialization.JsonNet/paket.references
+++ b/source/Halite.Serialization.JsonNet/paket.references
@@ -1,1 +1,2 @@
+Newtonsoft.Json
 JetBrains.Annotations

--- a/source/Halite.Tests/DummyLinks.cs
+++ b/source/Halite.Tests/DummyLinks.cs
@@ -1,19 +1,23 @@
-using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Halite.Tests
 {
     internal class DummyLinks : HalLinks
     {
-        public DummyLinks(SelfLink self, ThisLink @this, ThatLink that) : base(self)
+        public DummyLinks(SelfLink self, ThisLink @this, ThatLink that, IReadOnlyList<HalLink> those) : base(self)
         {
             This = @this;
             That = that;
+            Those = those;
         }
 
-        [JsonProperty("this")]
+        [HalRelation("this")]
         public ThisLink This { get; }
 
-        [JsonProperty("that")]
+        [HalRelation("that")]
         public ThatLink That { get; }
+
+        [HalRelation("those")]
+        public IReadOnlyList<HalLink> Those { get; }
     }
 }

--- a/source/Halite.Tests/EmbeddedTurtle.cs
+++ b/source/Halite.Tests/EmbeddedTurtle.cs
@@ -2,6 +2,7 @@ namespace Halite.Tests
 {
     public class EmbeddedTurtle : HalEmbedded
     {
+        [HalRelation("down")]
         public TurtleResource Down { get; set; }
     }
 }

--- a/source/Halite.Tests/HalLinkSerializationTests.cs
+++ b/source/Halite.Tests/HalLinkSerializationTests.cs
@@ -1,0 +1,48 @@
+using System;
+using Halite.Serialization.JsonNet;
+using Newtonsoft.Json;
+using Shouldly;
+using Xunit;
+
+namespace Halite.Tests
+{
+    public class HalLinkSerializationTests
+    {
+        [Fact]
+        public void VerifyBasicLinkSerialization()
+        {
+            var link = new HalLink("/user/{userId}");
+            var json = Serialize(link);
+            json.ShouldBe("{\"href\":\"/user/{userId}\"}");
+        }
+
+        [Fact]
+        public void VerifyBasicLinkSerializationWithRelativeUrl()
+        {
+            var link = new HalLink(new Uri("/user/{userId}", UriKind.Relative));
+            var json = Serialize(link);
+            json.ShouldBe("{\"href\":\"/user/{userId}\"}");
+        }
+
+        [Fact]
+        public void VerifyNamedLinkSerialization()
+        {
+            var link = new HalLink("/user/{userId}") { Name = "last" };
+            var json = Serialize(link);
+            json.ShouldBe("{\"name\":\"last\",\"href\":\"/user/{userId}\"}");
+        }
+
+        [Fact]
+        public void VerifyTypedLinkSerialization()
+        {
+            var link = new HalLink("/user/{userId}") { Type = "application/hal+json" };
+            var json = Serialize(link);
+            json.ShouldBe("{\"href\":\"/user/{userId}\",\"type\":\"application/hal+json\"}");
+        }
+
+        private static string Serialize<T>(T link) where T : HalLink
+        {
+            return JsonConvert.SerializeObject(link, new HalLinkJsonConverter());
+        }
+    }
+}

--- a/source/Halite.Tests/HalResourceDeserializationTests.cs
+++ b/source/Halite.Tests/HalResourceDeserializationTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Halite.Serialization.JsonNet;
 using Newtonsoft.Json;
 using Shouldly;
 using Xunit;
@@ -10,16 +11,16 @@ namespace Halite.Tests
         [Fact]
         public void VerifyDeserializeDummyResourceWithLinks()
         {
-            const string json = "{\"_links\":{\"this\":{\"href\":\"/this\"},\"that\":{\"href\":\"/that\"},\"self\":{\"href\":\"/lambda\"}}}";
-            DummyResourceWithLinks resource = JsonConvert.DeserializeObject<DummyResourceWithLinks>(json);
+            const string json = "{\"_links\":{\"this\":{\"href\":\"/this\"},\"that\":{\"href\":\"/that\"},\"self\":{\"href\":\"/lambda\"},\"those\":[{\"href\":\"/quux\"},{\"href\":\"/xuuq\"}]}}";
+            var resource = Deserialize<DummyResourceWithLinks>(json);
             resource.Links.Self.Href.ToString().ShouldBe("/lambda");
         }
 
         [Fact]
         public void VerifyDeserializeDummyResourceWithLinksAndNullEmbedded()
         {
-            const string json = "{\"_links\":{\"this\":{\"href\":\"/this\"},\"that\":{\"href\":\"/that\"},\"self\":{\"href\":\"/lambda\"}}}";
-            DummyResourceWithLinksAndEmbedded resource = JsonConvert.DeserializeObject<DummyResourceWithLinksAndEmbedded>(json);
+            const string json = "{\"_links\":{\"this\":{\"href\":\"/this\"},\"that\":{\"href\":\"/that\"},\"self\":{\"href\":\"/lambda\"},\"those\":[{\"href\":\"/quux\"},{\"href\":\"/xuuq\"}]}}";
+            var resource = Deserialize<DummyResourceWithLinksAndEmbedded>(json);
             resource.Links.Self.Href.ToString().ShouldBe("/lambda");
             resource.Embedded.ShouldBeNull();
         }
@@ -27,8 +28,8 @@ namespace Halite.Tests
         [Fact]
         public void VerifyDeserializeDummyResourceWithLinksAndEmbedded()
         {
-            const string json = "{\"_links\":{\"this\":{\"href\":\"/this\"},\"that\":{\"href\":\"/that\"},\"self\":{\"href\":\"/lambda\"}},\"_embedded\":{}}";
-            DummyResourceWithLinksAndEmbedded resource = JsonConvert.DeserializeObject<DummyResourceWithLinksAndEmbedded>(json);
+            const string json = "{\"_links\":{\"this\":{\"href\":\"/this\"},\"that\":{\"href\":\"/that\"},\"self\":{\"href\":\"/lambda\"},\"those\":[{\"href\":\"/quux\"},{\"href\":\"/xuuq\"}]},\"_embedded\":{}}";
+            var resource = Deserialize<DummyResourceWithLinksAndEmbedded>(json);
             resource.Links.Self.Href.ToString().ShouldBe("/lambda");
             resource.Embedded.ShouldNotBeNull();
         }
@@ -38,8 +39,16 @@ namespace Halite.Tests
         {
             const string json =
                 "{\"_links\":{\"self\":{\"href\":\"/turtle2\"}},\"_embedded\":{\"Down\":{\"_links\":{\"self\":{\"href\":\"/turtle1\"}},\"_embedded\":{\"Down\":{\"_links\":{\"self\":{\"href\":\"/turtle0\"}}}}}}}";
-            TurtleResource turtle = JsonConvert.DeserializeObject<TurtleResource>(json);
+            var turtle = Deserialize<TurtleResource>(json);
             VerifyTurtles(turtle, "/turtle2", "/turtle1", "/turtle0");
+        }
+
+        private static T Deserialize<T>(string json)
+        {
+            return JsonConvert.DeserializeObject<T>(json, 
+                new HalLinkJsonConverter(), 
+                new HalLinksJsonConverter(),
+                new HalResourceJsonConverter());
         }
 
         private static void VerifyTurtles(TurtleResource turtle, params string[] expectedLinks)

--- a/source/Halite.Tests/HalResourceDeserializationTests.cs
+++ b/source/Halite.Tests/HalResourceDeserializationTests.cs
@@ -45,10 +45,7 @@ namespace Halite.Tests
 
         private static T Deserialize<T>(string json)
         {
-            return JsonConvert.DeserializeObject<T>(json, 
-                new HalLinkJsonConverter(), 
-                new HalLinksJsonConverter(),
-                new HalResourceJsonConverter());
+            return JsonConvert.DeserializeObject<T>(json, new JsonSerializerSettings().ConfigureForHalite());
         }
 
         private static void VerifyTurtles(TurtleResource turtle, params string[] expectedLinks)

--- a/source/Halite.Tests/HalResourceSerializationTests.cs
+++ b/source/Halite.Tests/HalResourceSerializationTests.cs
@@ -75,18 +75,7 @@ namespace Halite.Tests
 
         private static string Serialize(object obj)
         {
-            var settings = new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                Converters = new List<JsonConverter>()
-                {
-                    new HalLinkJsonConverter(),
-                    new HalLinksJsonConverter(),
-                    new HalResourceJsonConverter()
-                }
-            };
-            return JsonConvert.SerializeObject(obj, settings);
+            return JsonConvert.SerializeObject(obj, new JsonSerializerSettings().ConfigureForHalite());
         }
-
     }
 }

--- a/source/Halite.Tests/HalTemplatedLinkSerializationTests.cs
+++ b/source/Halite.Tests/HalTemplatedLinkSerializationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Halite.Serialization.JsonNet;
 using Newtonsoft.Json;
 using Shouldly;
 using Xunit;
@@ -11,7 +12,7 @@ namespace Halite.Tests
         public void VerifyBasicTemplatedLinkSerialization()
         {
             var link = new HalTemplatedLink("/user/{userId}");
-            var json = JsonConvert.SerializeObject(link);
+            var json = Serialize(link);
             json.ShouldBe("{\"href\":\"/user/{userId}\",\"templated\":true}");
         }
 
@@ -19,7 +20,7 @@ namespace Halite.Tests
         public void VerifyBasicTemplatedLinkSerializationWithRelativeUrl()
         {
             var link = new HalTemplatedLink(new Uri("/user/{userId}", UriKind.Relative));
-            var json = JsonConvert.SerializeObject(link);
+            var json = Serialize(link);
             json.ShouldBe("{\"href\":\"/user/{userId}\",\"templated\":true}");
         }
 
@@ -27,7 +28,7 @@ namespace Halite.Tests
         public void VerifyNamedTemplatedLinkSerialization()
         {
             var link = new HalTemplatedLink("/user/{userId}") { Name = "last" };
-            var json = JsonConvert.SerializeObject(link);
+            var json = Serialize(link);
             json.ShouldBe("{\"name\":\"last\",\"href\":\"/user/{userId}\",\"templated\":true}");
         }
 
@@ -35,8 +36,13 @@ namespace Halite.Tests
         public void VerifyTypedTemplatedLinkSerialization()
         {
             var link = new HalTemplatedLink("/user/{userId}") { Type = "application/hal+json" };
-            var json = JsonConvert.SerializeObject(link);
+            var json = Serialize(link);
             json.ShouldBe("{\"href\":\"/user/{userId}\",\"templated\":true,\"type\":\"application/hal+json\"}");
+        }
+
+        private static string Serialize<T>(T link) where T : HalTemplatedLink
+        {
+            return JsonConvert.SerializeObject(link, new HalLinkJsonConverter());
         }
     }
 }

--- a/source/Halite.Tests/Halite.Tests.csproj
+++ b/source/Halite.Tests/Halite.Tests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="EmbeddedTurtle.cs" />
     <Compile Include="HalLinkDeserializationTests.cs" />
     <Compile Include="HalLinksDeserializationTests.cs" />
+    <Compile Include="HalLinkSerializationTests.cs" />
     <Compile Include="HalResourceDeserializationTests.cs" />
     <Compile Include="HalResourceSerializationTests.cs" />
     <Compile Include="HalTemplatedLinkSerializationTests.cs" />

--- a/source/Halite.Tests/Halite.Tests.csproj
+++ b/source/Halite.Tests/Halite.Tests.csproj
@@ -53,6 +53,10 @@
     <Compile Include="TurtleResource.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Halite.Serialization.JsonNet\Halite.Serialization.JsonNet.csproj">
+      <Project>{4631E21F-0ABA-42E4-A478-379B0656C969}</Project>
+      <Name>Halite.Serialization.JsonNet</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Halite\Halite.csproj">
       <Project>{670c2953-95c3-493c-a39c-987105130378}</Project>
       <Name>Halite</Name>
@@ -60,6 +64,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="paket.references" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Choose>

--- a/source/Halite.sln
+++ b/source/Halite.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halite", "Halite\Halite.csp
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{E6CD43F1-0D49-4558-96BA-9B16C8423B89}"
 	ProjectSection(SolutionItems) = preProject
-		paket.dependencies = paket.dependencies
+		..\paket.dependencies = ..\paket.dependencies
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halite.Tests", "Halite.Tests\Halite.Tests.csproj", "{E337DCEB-BE12-49A8-B251-848EBF81AF2D}"

--- a/source/Halite.sln
+++ b/source/Halite.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.8
+VisualStudioVersion = 15.0.27004.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halite", "Halite\Halite.csproj", "{670C2953-95C3-493C-A39C-987105130378}"
 EndProject
@@ -21,6 +21,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halite.Examples", "Halite.Examples\Halite.Examples.csproj", "{7024AE7A-7C53-43FD-9480-E24BF7B7E884}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halite.Examples.Tests", "Halite.Examples.Tests\Halite.Examples.Tests.csproj", "{056DBB00-0588-472B-BD52-2A470AE40B69}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halite.Serialization.JsonNet", "Halite.Serialization.JsonNet\Halite.Serialization.JsonNet.csproj", "{4631E21F-0ABA-42E4-A478-379B0656C969}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -56,6 +58,10 @@ Global
 		{056DBB00-0588-472B-BD52-2A470AE40B69}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{056DBB00-0588-472B-BD52-2A470AE40B69}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{056DBB00-0588-472B-BD52-2A470AE40B69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4631E21F-0ABA-42E4-A478-379B0656C969}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4631E21F-0ABA-42E4-A478-379B0656C969}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4631E21F-0ABA-42E4-A478-379B0656C969}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4631E21F-0ABA-42E4-A478-379B0656C969}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/Halite/HalLink.cs
+++ b/source/Halite/HalLink.cs
@@ -1,6 +1,5 @@
 using System;
 using JetBrains.Annotations;
-using Newtonsoft.Json;
 
 namespace Halite
 {
@@ -10,7 +9,6 @@ namespace Halite
     [Serializable]
     public class HalLink : HalLinkObject
     {
-        [JsonConstructor]
         public HalLink([CanBeNull] string href)
             : base(href)
         {

--- a/source/Halite/HalLinkObject.cs
+++ b/source/Halite/HalLinkObject.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using JetBrains.Annotations;
-using Newtonsoft.Json;
 
 namespace Halite
 {
@@ -31,7 +30,7 @@ namespace Halite
         /// If the value is a URI Template then the Link Object SHOULD have a
         /// "templated" attribute whose value is true.       
         /// </summary>
-        [JsonProperty("href", Order = 1)]
+        [HalProperty("href")]
         [NotNull]
         public Uri Href { get; }
 
@@ -43,7 +42,7 @@ namespace Halite
         /// 
         /// Its value SHOULD be considered false if it is undefined. 
         /// </summary>
-        [JsonProperty("templated", DefaultValueHandling = DefaultValueHandling.Ignore, Order = 2)]
+        [HalProperty("templated")]
         [CanBeNull]
         public abstract bool? Templated { get; }
 
@@ -53,7 +52,7 @@ namespace Halite
         /// Its value is a string used as a hint to indicate the media type
         /// expected when dereferencing the target resource.
         /// </summary>
-        [JsonProperty("type", DefaultValueHandling = DefaultValueHandling.Ignore, Order = 3)]
+        [HalProperty("type")]
         [CanBeNull]
         public string Type { get; set; }
 
@@ -63,7 +62,7 @@ namespace Halite
         /// Its value is a string used as a hint to indicate the media type
         /// expected when dereferencing the target resource.
         /// </summary>
-        [JsonProperty("deprecation", DefaultValueHandling = DefaultValueHandling.Ignore, Order = 4)]
+        [HalProperty("deprecation")]
         [CanBeNull]
         public bool? Deprecation { get; set; }
 
@@ -73,7 +72,7 @@ namespace Halite
         /// Its value MAY be used as a secondary key for selecting Link Objects
         /// which share the same relation type.
         /// </summary>
-        [JsonProperty("name", DefaultValueHandling = DefaultValueHandling.Ignore, Order = 0)]
+        [HalProperty("name")]
         [CanBeNull]
         public string Name { get; set; }
 
@@ -82,7 +81,7 @@ namespace Halite
         /// 
         /// Its value is a string which is URI that hints about the profile of the target resource.
         /// </summary>
-        [JsonProperty("profile", DefaultValueHandling = DefaultValueHandling.Ignore, Order = 5)]
+        [HalProperty("profile")]
         [CanBeNull]
         public Uri Profile { get; set; }
 
@@ -92,7 +91,7 @@ namespace Halite
         /// Its value is a string and is intended for labelling the link with a human-readable identifier 
         /// (as defined by [RFC5988]).
         /// </summary>
-        [JsonProperty("title", DefaultValueHandling = DefaultValueHandling.Ignore, Order = 6)]
+        [HalProperty("title")]
         [CanBeNull]
         public string Title { get; set; }
 
@@ -102,7 +101,7 @@ namespace Halite
         /// Its value is a string and is intended for indicating the language of the target resource 
         /// (as defined by [RFC5988]).
         /// </summary>
-        [JsonProperty("hreflang", DefaultValueHandling = DefaultValueHandling.Ignore, Order = 7)]
+        [HalProperty("hreflang")]
         [CanBeNull]
         public string HrefLang { get; set; }
     }

--- a/source/Halite/HalLinks.cs
+++ b/source/Halite/HalLinks.cs
@@ -18,7 +18,7 @@ namespace Halite
         /// <summary>
         /// Mandatory 'self' link for all resources.
         /// </summary>
-        [HalProperty("self")]
+        [HalRelation("self")]
         [NotNull]
         public SelfLink Self { get; }
     }

--- a/source/Halite/HalLinks.cs
+++ b/source/Halite/HalLinks.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using JetBrains.Annotations;
-using Newtonsoft.Json;
 
 namespace Halite
 {
@@ -19,7 +18,7 @@ namespace Halite
         /// <summary>
         /// Mandatory 'self' link for all resources.
         /// </summary>
-        [JsonProperty("self")]
+        [HalProperty("self")]
         [NotNull]
         public SelfLink Self { get; }
     }

--- a/source/Halite/HalPropertyAttribute.cs
+++ b/source/Halite/HalPropertyAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Halite
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class HalPropertyAttribute : Attribute
+    {
+        public HalPropertyAttribute(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+}

--- a/source/Halite/HalRelationAttribute.cs
+++ b/source/Halite/HalRelationAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Halite
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class HalRelationAttribute : Attribute
+    {
+        public HalRelationAttribute(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+}

--- a/source/Halite/HalResource.cs
+++ b/source/Halite/HalResource.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Newtonsoft.Json;
 
 namespace Halite
 {
@@ -7,7 +6,7 @@ namespace Halite
     public class HalResource<TLinks>
         where TLinks : HalLinks
     {
-        [JsonProperty("_links", Order = -10)]
+        [HalProperty("_links")]
         public TLinks Links { get; set; }
     }
 
@@ -16,7 +15,7 @@ namespace Halite
         where TLinks : HalLinks
         where TEmbedded : HalEmbedded
     {
-        [JsonProperty("_embedded", Order = 100, DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [HalProperty("_embedded")]
         public TEmbedded Embedded { get; set; }
     }
 }

--- a/source/Halite/HalTemplatedLink.cs
+++ b/source/Halite/HalTemplatedLink.cs
@@ -1,6 +1,5 @@
 using System;
 using JetBrains.Annotations;
-using Newtonsoft.Json;
 
 namespace Halite
 {
@@ -10,7 +9,6 @@ namespace Halite
     [Serializable]
     public class HalTemplatedLink : HalLinkObject
     {
-        [JsonConstructor]
         public HalTemplatedLink([CanBeNull] string href) : base(href)
         {
         }

--- a/source/Halite/Halite.csproj
+++ b/source/Halite/Halite.csproj
@@ -45,6 +45,7 @@
     <Compile Include="HalLinkObject.cs" />
     <Compile Include="HalLinks.cs" />
     <Compile Include="HalPropertyAttribute.cs" />
+    <Compile Include="HalRelationAttribute.cs" />
     <Compile Include="HalResource.cs" />
     <Compile Include="HalTemplatedLink.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
We don't want to tie users to Json.Net / a particular version of Json.Net. We will publish serialization/deserialization support using Json.Net as a separate nuget package.