### PR TITLE
Fix invalid cast exception thrown by HalLinksSubclassPropertySetterAnalyzer

### DIFF
--- a/source/analyzer/Halite.Analyzer.Test/HalLinksPropertySetterTests.cs
+++ b/source/analyzer/Halite.Analyzer.Test/HalLinksPropertySetterTests.cs
@@ -85,18 +85,7 @@ namespace Halite.Analyzer.Test
             public HalLink SomeLink { get; private set; }
         }
     }";
-            var expected = new DiagnosticResult
-            {
-                Id = "HalLinksPropertyDeclaration",
-                Message = String.Format("Property SomeLink in TypeName, a subclass of HalLinks, must not have externally accessible setter."),
-                Severity = DiagnosticSeverity.Warning,
-                Locations =
-                    new[] {
-                            new DiagnosticResultLocation("Test0.cs", 13, 44)
-                        }
-            };
-
-            VerifyCSharpDiagnostic(test, new DiagnosticResult[0]);
+            VerifyCSharpDiagnostic(test);
         }
 
         [Fact]

--- a/source/analyzer/Halite.Analyzer/HalLinksSubclassPropertySetterAnalyzer.cs
+++ b/source/analyzer/Halite.Analyzer/HalLinksSubclassPropertySetterAnalyzer.cs
@@ -40,7 +40,6 @@ namespace Halite
             var declarationNode = (PropertyDeclarationSyntax)context.Node;
             var parent = (ClassDeclarationSyntax)declarationNode.Parent;
             var propertySymbol = context.SemanticModel.GetDeclaredSymbol(declarationNode);
-            var classSymbol = ((ITypeSymbol)context.SemanticModel.GetDeclaredSymbol(parent));
             if (propertySymbol.ContainingType.IsHalLinks())
             {
 

--- a/source/analyzer/Halite.Analyzer/HalLinksSubclassPropertySetterAnalyzer.cs
+++ b/source/analyzer/Halite.Analyzer/HalLinksSubclassPropertySetterAnalyzer.cs
@@ -38,7 +38,6 @@ namespace Halite
         private static void AnalyzePropertyDeclarationNoSetter(SyntaxNodeAnalysisContext context)
         {
             var declarationNode = (PropertyDeclarationSyntax)context.Node;
-            var parent = (ClassDeclarationSyntax)declarationNode.Parent;
             var propertySymbol = context.SemanticModel.GetDeclaredSymbol(declarationNode);
             if (propertySymbol.ContainingType.IsHalLinks())
             {
@@ -46,6 +45,7 @@ namespace Halite
                 var accessorList = declarationNode.AccessorList;
                 if (accessorList.Accessors.Any(a => a.Keyword.Kind() == SyntaxKind.SetKeyword))
                 {
+                    var parent = (TypeDeclarationSyntax)declarationNode.Parent;
                     var setter = accessorList.Accessors.Single(a => a.Keyword.Kind() == SyntaxKind.SetKeyword);
                     if (setter.Modifiers.Any())
                     {

--- a/source/analyzer/Halite.Analyzer/HalLinksSubclassPropertySetterAnalyzer.cs
+++ b/source/analyzer/Halite.Analyzer/HalLinksSubclassPropertySetterAnalyzer.cs
@@ -41,7 +41,6 @@ namespace Halite
             var propertySymbol = context.SemanticModel.GetDeclaredSymbol(declarationNode);
             if (propertySymbol.ContainingType.IsHalLinks())
             {
-
                 var accessorList = declarationNode.AccessorList;
                 if (accessorList.Accessors.Any(a => a.Keyword.Kind() == SyntaxKind.SetKeyword))
                 {
@@ -49,20 +48,19 @@ namespace Halite
                     var setter = accessorList.Accessors.Single(a => a.Keyword.Kind() == SyntaxKind.SetKeyword);
                     if (setter.Modifiers.Any())
                     {
-                        if (!setter.Modifiers.All(m => m.Kind() == SyntaxKind.PrivateKeyword))
+                        if (setter.Modifiers.Any(m => m.Kind() != SyntaxKind.PrivateKeyword))
                         {
-                            var diagnostic = Diagnostic.Create(HalLinksPropertyNoSetterRule, setter.GetLocation(), new object[] { declarationNode.Identifier.Value, parent.Identifier.Value });
+                            var diagnostic = Diagnostic.Create(HalLinksPropertyNoSetterRule, setter.GetLocation(), declarationNode.Identifier.Value, parent.Identifier.Value);
                             context.ReportDiagnostic(diagnostic);
                         }
                     }
                     else
                     {
-                        var diagnostic = Diagnostic.Create(HalLinksPropertyNoSetterRule, setter.GetLocation(), new object[] { declarationNode.Identifier.Value, parent.Identifier.Value });
+                        var diagnostic = Diagnostic.Create(HalLinksPropertyNoSetterRule, setter.GetLocation(), declarationNode.Identifier.Value, parent.Identifier.Value);
                         context.ReportDiagnostic(diagnostic);
                     }
                 }
             }
         }
-
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/126619/39754409-68a2c1e8-52c2-11e8-9436-9492b0425b51.png)

`HalLinksSubclassPropertySetterAnalyzer` throws `System.InvalidCastException` while checking types for privates setters. 

Moving the `parent` variable closer to scope and within the `IsHalLinks()`-check. Also using the superclass `TypeDeclarationSyntax`